### PR TITLE
更新社区首页

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -19,9 +19,9 @@
         <div class="col-lg-2 col-md-0 col-sm-0"></div>
         <div class="col-lg-4 col-md-6 col-sm-6">
           <div class="social-network discourse">
-            <h4><a href="http://discourse.juliacn.com/">Discourse</a></h4>
+            <h4><a href="https://discourse.juliacn.com/">Discourse</a></h4>
             <p>
-              Discussion forums
+              JuliaCN 中文讨论社区
             </p>
           </div>
         </div>
@@ -29,7 +29,7 @@
           <div class="social-network github">
             <h4><a href="https://github.com/JuliaCN">Github</a></h4>
             <p>
-              Source code and development
+              JuliaCN 中文开源组织
             </p>
           </div>
         </div>
@@ -40,17 +40,17 @@
         <div class="col-lg-2 col-md-0 col-sm-0"></div>
         <div class="col-lg-4 col-md-6 col-sm-6">
           <div class="social-network QQ">
-            <h4>QQ群</h4>
+            <h4>QQ 群</h4>
             <p>
-			  Julia中文社区，316628299
+              中文社区讨论群：316628299
             </p>
           </div>
         </div>
         <div class="col-lg-4 col-md-6 col-sm-6">
           <div class="social-network zhihu">
-            <h4>知乎</h4>
+            <h4><a href="https://www.zhihu.com/topic/19678370/hot">知乎</a></h4>
             <p>
-              Julia板块下提问即可
+              提问时带上 “Julia（编程语言）” 标签即可
             </p>
           </div>
         </div>

--- a/_includes/ides.html
+++ b/_includes/ides.html
@@ -6,7 +6,7 @@
       <div class="col-lg-4 col-md-3 language-features"><hr/></div>
       <div class="col-lg-4 col-md-6 language-features section-heading">
         <h2 class="lead secondary-heading">
-          Julia Editors and IDEs
+          编辑器与开发环境
         </h2>
       </div>
       <div class="col-lg-4 col-md-3 language-features"><hr/></div>
@@ -21,7 +21,7 @@
           <img src="v2/img/atom.png" />
         </a>
         <h6 class="outer-link">
-          <a class="link extra-link" href="http://junolab.org/" target="_blank">Atom Plugin</a>
+          <a class="link extra-link" href="http://junolab.org/" target="_blank">Atom 插件</a>
         </h6>
       </div>
       <div class="col-lg-4 col-md-6 ide ide-feature">
@@ -30,7 +30,7 @@
           <img src="v2/img/vscode.png" />
         </a>
         <h6 class="outer-link">
-          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/julia-vscode" target="_blank">VS Code Extension</a>
+          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/julia-vscode" target="_blank">VS Code 扩展</a>
         </h6>
       </div>
       <div class="col-lg-4 col-md-6 ide ide-feature">
@@ -48,7 +48,7 @@
           <img src="images/vim.png" />
         </a>
         <h6 class="outer-link">
-          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/julia-vim" target="_blank">Vim plugin</a>
+          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/julia-vim" target="_blank">Vim 插件</a>
         </h6>
       </div>
       <div class="col-lg-4 col-md-6 ide ide-feature">
@@ -57,7 +57,7 @@
           <img src="images/emacs.png" />
         </a>
         <h6 class="outer-link">
-          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/julia-emacs" target="_blank">Emacs plugin</a>
+          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/julia-emacs" target="_blank">Emacs 插件</a>
         </h6>
       </div>
       <div class="col-lg-4 col-md-6 ide ide-feature">
@@ -66,7 +66,7 @@
           <img src="images/sublime.png" />
         </a>
         <h6 class="outer-link">
-          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/Julia-sublime" target="_blank">Sublime Text plugin</a>
+          <a class="link extra-link" href="https://github.com/JuliaEditorSupport/Julia-sublime" target="_blank">Sublime Text 插件</a>
         </h6>
       </div>
     </div>

--- a/_includes/jumbotron.html
+++ b/_includes/jumbotron.html
@@ -3,10 +3,10 @@
   <div class="jumbotron" style="text-align: center;" id="main-jumbo">
     <div class="container page-heading">
       <h1 class="display-5 main-heading">
-        Julia中文社区
+        Julia 中文社区
       </h1>
       <h2 class="lead secondary-heading">
-       社区驱动, 致力于Julia语言的中文支持的开源组织
+        社区驱动，致力于 Julia 语言的中文支持的开源组织
       </h2>
     </div>
   </div>

--- a/_includes/languagefeatures.html
+++ b/_includes/languagefeatures.html
@@ -4,7 +4,7 @@
     <div class="col-lg-4 col-md-3 language-features "><hr/></div>
     <div class="col-lg-4 col-md-6 language-features section-heading">
       <h2 class="lead secondary-heading">
-        简而言之, Julia语言就是
+        简而言之, Julia 语言就是
       </h2>
     </div>
     <div class="col-lg-4 col-md-3 language-features"><hr/></div>
@@ -16,43 +16,53 @@
     <div class="col-lg-4 col-md-6 feature">
       <h4>快!</h4>
       <p>
-        Julia一开始就是为<a href="/benchmarks/">高性能</a>设计的。
-        Julia程序被LLVM编译成高效的多平台机器码。
+        Julia 一开始就是为<a href="/benchmarks/">高性能</a>设计的。
+        Julia 程序被 LLVM 编译成高效的多平台机器码。
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
       <h4>动态</h4>
       <p>
-        Julia是动态类型语言，感觉上像脚本语言，有很好的交互开发支持。
+        Julia 是动态类型语言，感觉上像脚本语言，有很好的交互开发支持。
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>非强制的类型</h4>
+      <h4>可选类型</h4>
       <p>
-        Julia有丰富的数据类型描述语言，类型声明可以使程序更清晰可靠。
+        Julia 有丰富的数据类型描述语言，类型声明可以使程序更清晰可靠。
       </p>
     </div>
 
     <div class="col-lg-4 col-md-6 feature">
-      <h4>通用型</h4>
+      <h4>通用</h4>
       <p>
-        Julia使用多分派范式, 容易表达很多面向对象和函数编程的模式。
-        标准库提供异步输入/输出，进程控制，日志，性能分析，库管理器，还有更多。
+        Julia 使用多分派范式, 容易表达很多面向对象和函数编程的模式。
+        标准库提供异步输入/输出、进程控制、日志、性能分析、包管理器，
+        还有更多优秀的库等你发现。
       </p>
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>技术</h4>
+      <h4>易用</h4>
       <p>
-        Julia的强项是数值计算。它的语法非常适合数学计算，支持很多数值计算数据类型, 并行计算拿来就可以用。
-        Julia的多分派机制很自然地支持自定义数字和数组类的数据类型。
+        Julia 拥有高阶的语法。
+        这让具有不同编程语言背景和经验的程序员都能使用它。
+      </p>
+      <!-- <h4>技术</h4>
+      <p>
+        Julia 的强项是数值计算。它的语法非常适合数学计算，支持很多数值计算数据类型, 并行计算拿来就可以用。
+        Julia 的多分派机制很自然地支持自定义数字和数组类的数据类型。
         datatypes.
-      </p>
+      </p> -->
     </div>
     <div class="col-lg-4 col-md-6 feature">
-      <h4>可组合</h4>
+      <h4>开源</h4>
       <p>
-        Julia库用在一起很自然。比如单元矩阵，货币和颜色数据表列, 等等拿来可用，性能优异。
+        Julia 是开源免费的，所有的源代码都可以在 Github 上看到。
       </p>
+      <!-- <h4>可组合</h4>
+      <p>
+        Julia 库用在一起很自然。比如单元矩阵，货币和颜色数据表列, 等等拿来可用，性能优异。
+      </p> -->
     </div>
   </div>
 

--- a/_includes/mainmenu.html
+++ b/_includes/mainmenu.html
@@ -21,12 +21,15 @@
           <a class="nav-link" href="/downloads">下载</a>
         </li>
         <li class="nav-item flex-md-fill text-md-center">
-          <a class="nav-link" href="http://docs.juliacn.com/">文档</a>
+          <a class="nav-link" href="https://docs.juliacn.com/">文档</a>
         </li>
         <li class="nav-item {% if current_page[1] == 'blog' %} active {% endif %} flex-md-fill text-md-center">
-          <a class="nav-link" href="/blog/">Blog</a>
+          <a class="nav-link" href="/blog/">博客</a>
         </li>
-        <li class="nav-item {% if current_page[1] == '活动' %} active {% endif %} flex-md-fill text-md-center">
+        <li class="nav-item flex-md-fill text-md-center">
+          <a class="nav-link" href="https://discourse.juliacn.com/">中文社区</a>
+        </li>
+        <li class="nav-item {% if current_page[1] == 'meetups' %} active {% endif %} flex-md-fill text-md-center">
           <a class="nav-link" href="/meetups">活动</a>
         </li>
       </ul>

--- a/_includes/packages.html
+++ b/_includes/packages.html
@@ -26,16 +26,24 @@
       </div>
 -->
       <p>
-        Julia 已经被下载超过两百万次。Julia的社区开发了一千九百多外部库。这些包括各种数学库，数据处理工具，以及通用计算库等。除此之外，您还可以很容易地调用
-        from <a href="https://github.com/JuliaPy/PyCall.jl">Python</a>, <a href="https://github.com/JuliaInterop/RCall.jl">R</a>, <a href="https://docs.julialang.org/en/stable/manual/calling-c-and-fortran-code/#Calling-C-and-Fortran-Code-1">C/Fortran</a>, <a href="https://github.com/Keno/Cxx.jl">C++</a>, and <a href="https://github.com/JuliaInterop/JavaCall.jl">Java</a>等的外部库. 如果您找不到需要的，可以在<a href="http://discourse.juliacn.org">Discourse</a>询问, 自己贡献更好！
+        Julia 已经被下载超过两百万次。Julia 的社区开发了一千九百多外部库。这些包括各种数学库，数据处理工具，以及通用计算库等。除此之外，您还可以很容易地调用
+        <a href="https://github.com/JuliaPy/PyCall.jl">Python</a>,
+        <a href="https://github.com/JuliaInterop/RCall.jl">R</a>,
+        <a href="https://docs.julialang.org/en/stable/manual/calling-c-and-fortran-code/#Calling-C-and-Fortran-Code-1">C/Fortran</a>,
+        <a href="https://github.com/Keno/Cxx.jl">C++</a>,
+        和 
+        <a href="https://github.com/JuliaInterop/JavaCall.jl">Java</a>
+        等的外部库. 如果您找不到需要的，可以在
+        <a href="http://discourse.juliacn.org">Julia 中文社区</a>
+        询问, 自己贡献更好！
       </p>
 
       <br /><br />
 
       <div class="row">
         <div class="col-12" style="text-align: center">
-          <a class="btn btn-sm btn-outline-danger" href="//juliaobserver.com">外部库探寻</a>
-          <a class="btn btn-sm btn-outline-danger" href="//pkg.julialang.org/pulse">生态系统动态</a>
+          <a class="btn btn-sm btn-outline-danger" href="https://juliaobserver.com">外部库探寻</a>
+          <a class="btn btn-sm btn-outline-danger" href="https://pkg.julialang.org/pulse">生态系统动态</a>
         </div>
       </div>
 

--- a/_layouts/meetups.html
+++ b/_layouts/meetups.html
@@ -9,9 +9,11 @@
   {% include mainmenu.html %}
 
   <br />
-  
-  {{ content }}
 
+  <div class="container">
+    {{ content }}
+  </div>
+  
   {% include footer.html %}
   {% include scripts.html %}
 </body>

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -1,121 +1,366 @@
 ---
 layout: homepage
-title:  下载Julia
+title:  下载 Julia
 ---
 
+<!-- 1.container = Julia 下载页开始 -->
+<div class="container">
+
+  <!-- 1.row = heading: Download Julia -->
   <div class="row">
     <div class="col-12">
-      <h1>下载Julia</h1>
+      <h1>下载 Julia</h1>
     </div>
   </div>
 
+  <!-- 2.row = github star -->
   <div class="row">
     <div class="col-12">
-        <p>如果你喜欢Julia语言，请考虑在
-<a href="https://github.com/JuliaLang/julia" target="_blank" rel="noopener">GitHub</a>上给我们一个star并向他人传播这个词语。</p>
- <br />
+      <p>如果你喜欢 Julia 语言，请考虑在
+      <a href="https://github.com/JuliaLang/julia" target="_blank" rel="noopener">GitHub</a>
+      上给我们一个 star，并向他人传播这个词语。</p>
     </div>
   </div>
 
+  <br />
+
+  <!-- 3.row = running julia -->
   <div class="row">
     <div class="col-12">
-<h1>Current Release (v0.6.4)</h1>
-<p>我们提供了几种方式来让你们运行Julia：</p>
-<ul>
-<li>在命令行中使用Julia命令行界面</li>
-<li>在浏览器中通过<a href="https://www.juliabox.com" target="_blank" rel="noopener">JuliaBox.com</a>在Jupyter notebook上运行。不需要预先安装，只要点开你的浏览器然后注册并开始计算即可。</li>
-<li>下载由<a href="http://juliacomputing.com" target="_blank" rel="noopener">Julia Computing</a>提供的<a href="http://juliacomputing.com/products/juliapro.html" target="_blank" rel="noopener">JuliaPro</a>。JuliaPro是一个集成了常用外置库的Julia发行版。它包括了<a href="http://junolab.org" target="_blank" rel="noopener">Juno IDE</a>，<a href="https://github.com/Keno/Gallium.jl" target="_blank" rel="noopener">Gallium debugger</a>，和其它一系列用于画图，优化，机器学习，数据库等外部库。</li>
-</ul>
-<p>此外，你可以安装<a href="https://github.com/JuliaPlots/Plots.jl" target="_blank" rel="noopener">Plots.jl</a>，一个集成了大部分Julia绘图后端的绘图前端库。其绘图能力由不同的后端提供，例如
-<a href="https://github.com/JuliaPy/PyPlot.jl" target="_blank" rel="noopener">PyPlot.jl</a> 和 <a href="http://gadflyjl.org" target="_blank" rel="noopener">Gadfly.jl</a>。通过查看<a href="plotting.html">绘图指引</a>来安装绘图包。如果你在
-使用JuliaBox，那么所有以上提到的绘图包都是预先安装的。</p>
+      我们提供了几种方式供大家运行 Julia：
+      <ul>
+        <li> 在命令行中使用 Julia REPL。
+        <li> 在浏览器中通过
+          <a href="https://www.juliabox.com" target="_blank" rel="noopener">JuliaBox.com</a>
+          在 Jupyter notebook 上运行。不需要任何下载或安装——只要点开浏览器、注册，就可以开始计算啦。
+        <li> 下载由
+          <a href="https://juliacomputing.com" target="_blank" rel="noopener">Julia Computing</a>
+          提供的
+          <a href="https://juliacomputing.com/products/juliapro.html" target="_blank" rel="noopener">JuliaPro</a>。
+          JuliaPro 是一个集成了常用外置库的 Julia 发行版。
+          它包括了
+          <a href="https://junolab.org" target="_blank" rel="noopener">Juno IDE</a>、
+          <a href="https://github.com/Keno/Gallium.jl" target="_blank" rel="noopener">Gallium debugger</a>
+          和其它一系列用于画图、优化、机器学习、数据库的外部库。（需要注册才能下载）
+      </ul>
 
-<h2>Julia (命令行版本)</h2>
-<table class="downloads table table-hover table-responsive table-bordered">
-<tbody>
-<tr>
-    <th rowspan="2"> Windows 自解压文档（.exe） <a href="platform.html#windows">[帮助]</a></th>
-    <td colspan="3"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-win32.exe" target="_blank" rel="noopener">32-bit</a> </td>
-    <td colspan="3"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-win64.exe" target="_blank" rel="noopener">64-bit</a> </td>
-</tr>
-<tr>
-    <td colspan="6">Windows 7/Windows Server 2012 用户同时需要安装 <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in" target="_blank" rel="noopener">TLS "Easy Fix" update</a>, and <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme" target="_blank" rel="noopener">Windows Management Framework 3.0 or later</a></td>
-</tr>
-<tr>
-    <th> macOS 安装包（.dmg） <a href="platform.html#macos">[帮助]</a></th>
-    <td colspan="6"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-mac64.dmg" target="_blank" rel="noopener">10.8+ 64-bit</a> </td>
-</tr>
-<tr>
-    <th> 通用Linux二进制文件（x86） <a href="platform.html#generic-binaries">[帮助]</a></th>
-    <td colspan="3"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-i686.tar.gz" target="_blank" rel="noopener">32-bit</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-i686.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)</td>
-    <td colspan="3"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-x86_64.tar.gz" target="_blank" rel="noopener">64-bit</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-x86_64.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)</td>
-</tr>
-<tr>
-    <th> 通用Linux二进制文件（ARM） </th>
-    <td colspan="3"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-armv7l.tar.gz" target="_blank" rel="noopener">32-bit (armv7-a hard float)</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-armv7l.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)</td>
-    <td colspan="3"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-aarch64.tar.gz" target="_blank" rel="noopener">64-bit (armv8-a)</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-linux-aarch64.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)</td>
-</tr>
-<tr>
-    <th> 通用FreeBSD二进制文件（x86） <a href="platform.html#generic-binaries">[help]</a></th>
-    <td colspan="6"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-freebsd-x86_64.tar.gz" target="_blank" rel="noopener">64-bit</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-freebsd-x86_64.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)</td>
-</tr>
-<tr>
-    <th> 源码 </th>
-    <td colspan="2"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4.tar.gz" target="_blank" rel="noopener">Tarball</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4.tar.gz.asc" target="_blank" rel="noopener">GPG</a>) </td>
-    <td colspan="2"> <a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-full.tar.gz" target="_blank" rel="noopener">Tarball with dependencies</a>
-        (<a href="https://mirrors.zju.edu.cn/julia/releases/v0.6/julia-0.6.4-full.tar.gz.asc" target="_blank" rel="noopener">GPG</a>) </td>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.6.4" target="_blank" rel="noopener">GitHub</a> </td>
-</tr>
-</tbody></table>
+      <p>
+        此外，你可以安装
+        <a href="https://github.com/JuliaPlots/Plots.jl" target="_blank" rel="noopener">Plots.jl</a>，
+        一个集成了大部分Julia绘图后端的绘图前端库。
+        其绘图能力由不同的后端提供，例如
+        <a href="https://github.com/JuliaPy/PyPlot.jl" target="_blank" rel="noopener">PyPlot.jl</a> 
+        和
+        <a href="https://gadflyjl.org" target="_blank" rel="noopener">Gadfly.jl</a>。
+        <!-- NOTE! plotting 页面尚未翻译 -->
+        <!-- 通过查看<a href="plotting.html">绘图指引</a>来安装绘图包。 -->
+        如果你在使用 JuliaBox，那么所有以上提到的绘图包都是预先安装的。
+      </p>
+    </div>
+  </div><!-- running julia //END -->
 
-<p>如果您安装Julia出现了问题，请查看<a href="platform.html">特定平台的安装指南</a>。可以通过<a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.6.4.md5" target="_blank" rel="noopener">MD5</a>和<a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.6.4.sha256" target="_blank" rel="noopener">SHA256</a>格式来校验和（checksum）。</p>
-<p>如果您无法使用上面提供的安装方式，请<a href="https://github.com/JuliaLang/julia/issues" target="_blank" rel="noopener">提交一个issue</a>。</p>
-<h1>即将到来的测试版本 (v0.7.0-beta2)</h1>
-<p>我们当前正在测试Julia的下一个release版本，v0.7.0。如果您安装Julia出现了问题，请查看<a href="platform.html">特定平台的安装指南</a>。类似于最新的稳定版，有<a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.7.0-beta2.md5" target="_blank" rel="noopener">MD5</a>
-和 <a href="https://julialang-s3.julialang.org/bin/checksums/julia-0.7.0-beta2.sha256" target="_blank" rel="noopener">SHA256</a>两种格式可以用于校验和（checksum）。请在下面下载测试版本并向
-<a href="https://github.com/JuliaLang/julia/issues" target="_blank" rel="noopener">issue tracker</a>报告您遇到的错误。</p>
-<table class="downloads table table-hover table-responsive table-bordered">
-<tbody>
-<tr>
-    <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[help]</a></th>
-    <td colspan="3"> <a href="downloads/julia-0.7.0-beta2-win32.exe">32-bit</a> </td>
-    <td colspan="3"> <a href="downloads/julia-0.7.0-beta2-win64.exe">64-bit</a> </td>
-</tr>
-<tr>
-    <td colspan="6">Windows 7/Windows Server 2012 用户同时需要安装 <a href="https://support.microsoft.com/en-us/help/3140245/update-to-enable-tls-1-1-and-tls-1-2-as-a-default-secure-protocols-in" target="_blank" rel="noopener">TLS "Easy Fix" update</a>, and <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme" target="_blank" rel="noopener">Windows Management Framework 3.0 or later</a></td>
-</tr>
-<tr>
-    <th> macOS 安装包（.dmg） <a href="platform.html#macos">[帮助]</a></th>
-    <td colspan="6"> <a href="downloads/julia-0.7.0-beta2-mac64.dmg">10.8+ 64-bit</a> </td>
-</tr>
-<tr>
-    <th> 通用Linux二进制文件（x86） <a href="platform.html#generic-binaries">[帮助]</a></th>
-    <td colspan="3"> <a href="downloads/julia-0.7.0-beta2-linux-i686.tar.gz">32-bit</a>
-        (<a href="downloads/julia-0.7.0-beta2-linux-i686.tar.gz.asc">GPG</a>)</td>
-    <td colspan="3"> <a href="downloads/julia-0.7.0-beta2-linux-x86_64.tar.gz">64-bit</a>
-        (<a href="downloads/julia-0.7.0-beta2-linux-x86_64.tar.gz.asc">GPG</a>)</td>
-</tr>
-<tr>
-    <th> 通用FreeBSD二进制文件（x86） <a href="platform.html#generic-binaries">[help]</a></th>
-    <td colspan="6"> <a href="downloads/julia-0.7.0-freebsd-x86_64.tar.gz">64-bit</a>
-        (<a href="downloads/julia-0.7.0-freebsd-x86_64.tar.gz.asc">GPG</a>)</td>
-</tr>
-<tr>
-    <th> 源码 </th>
-    <td colspan="2"> <a href="downloads/julia-0.7.0-beta2.tar.gz">Tarball</a>
-        (<a href="downloads/julia-0.7.0-beta2.tar.gz.asc">GPG</a>) </td>
-    <td colspan="2"> <a href="downloads/julia-0.7.0-beta2-full.tar.gz">Tarball with dependencies</a>
-        (<a href="downloads/julia-0.7.0-beta2-full.tar.gz.asc">GPG</a>) </td>
-    <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.7.0-beta2" target="_blank" rel="noopener">GitHub</a> </td>
-</tr>
-</tbody>
-</table>
+  <br />
+
+  <!-- 4.row = Current stable release -->
+  <div class="row">
+    <div class="col-12">
+      <h2>当前的稳定版本 (v1.0.2)</h2>
+      <p>
+        如果你准备从 Julia 0.6.0 迁移到新版本，我们强烈建议你使用 Julia 的过渡版本 <a href="#0.7.0">v0.7.0</a>，而不是直接一步迁移到 v1.0.0。
+        v1.0.0 和 v0.7.0 两个版本是大致相同的。二者最主要的区别是：0.7.0 包含了函数弃用警告 (deprecation warnings)，
+        如果你使用了 1.0.0 中功能或行为有所改变的函数，在 0.7.0 中 Julia 会给你一个弃用警告。
+        举个例子：你在程序中使用了 1.0.0 弃用的方法，在 0.7.0 中会产生一个警告。而在 1.0.0 中会导致 MethodError 错误。
+        因为这些方法在 1.0.0 中已经被移除了。
+        所以即使你在 1.0 上进行开发，保留一份 Julia 0.7 的副本是十分有用的，这样你可以随时检查某些 0.6 的方法在新版本上还能否工作。
+
+        注意！1.0.x 版本包含了 0.7 没有的 bug 修复补丁。
+      </p>
+
+      <p>
+        下面的下载链接均指向
+        <a href="https://mirrors.ustc.edu.cn/julia/">USTC 的 Julia 镜像源</a>。
+        镜像源中
+        <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/">Julia 1.0.x</a>
+        的最新稳定版会滚动更新，新的版本会覆盖老版本
+        (即：镜像源更新到 1.0.3 后，会只保留 1.0.3 的安装包，并删掉同文件夹下 1.0.2 及以前的老安装包)。
+        故“当前的稳定版本”的链接很容易失效。
+        <br />
+        <b>若连接失效请到
+          <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/">USTC镜像源: Julia/v1.0</a>
+          下载最新的“当前的稳定版本”。
+        </b>
+      </p>
+      
+      <table class="downloads table table-hover table-responsive table-bordered">
+        <tbody>
+          <tr>
+            <th rowspan="2"> Windows 自解压文档（.exe）<a href="platform.html#windows">[帮助]</a> </th>
+            <td colspan="3"> <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-win32.exe" target="_blank" rel="noopener">32-bit</a> </td>
+            <td colspan="3"> <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-win64.exe" target="_blank" rel="noopener">64-bit</a> </td>
+          </tr>
+          <tr>
+            <td colspan="6">
+              Windows 7/Windows Server 2012 用户需要安装
+              <a href="https://docs.microsoft.com/en-us/powershell/wmf/readme" target="_blank" rel="noopener">Windows Management Framework 3.0 或更新版本</a>
+            </td>
+          </tr>
+          <tr>
+            <th> macOS 10.8+ 安装包（.dmg）<a href="platform.html#macos">[帮助]</a> </th>
+            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-mac64.dmg" target="_blank" rel="noopener">64-bit</a> </td>
+          </tr>
+          <tr>
+            <th> 通用 Linux 二进制文件（x86）<a href="platform.html#generic-binaries">[帮助]</a> </th>
+            <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-linux-i686.tar.gz" target="_blank" rel="noopener">32-bit</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-linux-i686.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)
+            </td>
+            <td colspan="3">
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-linux-x86_64.tar.gz" target="_blank" rel="noopener">64-bit</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-linux-x86_64.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> 通用 Linux 二进制文件（ARM）</th>
+            <td colspan="6">
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.0-linux-armv7l.tar.gz">32-bit (ARMv7-a hard float)</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.0-linux-armv7l.tar.gz.asc">GPG</a>)
+              <br />
+              注意！此为 1.0.0 版本的下载链接。新版的下载链接 USTC 镜像源尚未更新。
+            </td>
+            <!-- NOTE! ARMv7l 只有 1.0.0 和 1.0.3 的；新版本 1.0.3 USTC 镜像源尚未更新 -->
+            <!-- <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.3-linux-armv7l.tar.gz" target="_blank" rel="noopener">32-bit (armv7-a hard float)</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.3-linux-armv7l.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)
+            </td>
+            <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.3-linux-aarch64.tar.gz" target="_blank" rel="noopener">64-bit (armv8-a)</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.3-linux-aarch64.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)
+            </td> -->
+          </tr>
+          <tr>
+            <th> 通用 FreeBSD 二进制文件（x86）<a href="platform.html#generic-binaries">[帮助]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-freebsd-x86_64.tar.gz" target="_blank" rel="noopener">64-bit</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-freebsd-x86_64.tar.gz.asc" target="_blank" rel="noopener">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> 源码 </th>
+            <td colspan="2">
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2.tar.gz" target="_blank" rel="noopener">Tarball</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2.tar.gz.asc" target="_blank" rel="noopener">GPG</a>) 
+            </td>
+            <td colspan="2"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-full.tar.gz" target="_blank" rel="noopener">Tarball with dependencies</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2-full.tar.gz.asc" target="_blank" rel="noopener">GPG</a>) 
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.0.2" target="_blank" rel="noopener">GitHub</a> </td>
+          </tr>
+        </tbody>
+      </table><!-- Current stable release table end -->
+
+      <p>
+        如果您安装 Julia 出现了问题，请查看<a href="platform.html">特定平台的安装指南</a>。
+        我们提供了
+        <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2.md5" target="_blank" rel="noopener">MD5</a>
+        和
+        <a href="https://mirrors.ustc.edu.cn/julia/releases/v1.0/julia-1.0.2.sha256" target="_blank" rel="noopener">SHA256</a>
+        格式的校验和进行验证。
+      </p>
+      <p>
+        如果您无法使用上面提供的安装方式，请<a href="https://github.com/JuliaLang/julia/issues" target="_blank" rel="noopener">提交一个 issue</a>。
+      </p>
+    </div>
+  </div><!-- Current stable release //END -->
+
+  <br />
+
+  <!-- 5.row = Previous stable release -->
+  <div class="row">
+    <div class="col-12">
+      <h2 id="0.7.0">前一个稳定版本 (v0.7.0)</h2>
+      <p>
+        Julia v0.7.0 是一个过渡版本，用于帮助人们从 Julia v0.6 迁移到 Julia v1.0。
+      </p>
+  
+      <table class="downloads table table-hover table-responsive table-bordered">
+        <tbody>
+          <tr>
+            <th rowspan="2"> Windows 自解压文档（.exe）<a href="platform.html#windows">[帮助]</a></th>
+            <td colspan="3"> <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-win32.exe">32-bit</a>
+            </td>
+            <td colspan="3"> <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-win64.exe">64-bit</a>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="6">Windows 7/Windows Server 2012 用户需要安装
+              <a href="https://docs.microsoft.com/en-us/powershell/wmf/overview">Windows Management Framework 3.0 或更新版本</a></td>
+          </tr>
+          <tr>
+            <th> macOS 安装包（.dmg）<a href="platform.html#macos">[帮助]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-mac64.dmg">64-bit</a>
+            </td>
+          </tr>
+          </tr>
+          <tr>
+            <th> 通用 Linux 二进制文件（x86）<a href="platform.html#generic-binaries">[帮助]</a></th>
+            <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-linux-i686.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-linux-x86_64.tar.gz">64-bit</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-linux-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> 通用 FreeBSD 二进制文件（x86）<a href="platform.html#generic-binaries">[帮助]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-freebsd-x86_64.tar.gz">64-bit</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          </tr>
+          <tr>
+            <th> 源码 </th>
+            <td colspan="2"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0.tar.gz">Tarball</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> 
+              <a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-full.tar.gz">Tarball with dependencies</a>
+              (<a href="https://mirrors.ustc.edu.cn/julia/releases/v0.7/julia-0.7.0-full.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v0.7.0">GitHub</a> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div><!-- Previous stable release //END -->
+
+  <!-- 6.row = Upcoming release -->
+  <!-- <div class="row">
+    <div class="col-12">
+      <h2>即将到来的测试版本 (v1.1.0-rc1)</h2>
+      <p>
+        We're currently testing a release candidate for Julia v1.1.0, the first minor release
+        in the 1.x series of releases. We encourage developers and interested users to try it
+        out and report any issues they encounter. As a prerelease, it should not be considered
+        production-ready; it's intended to give users a chance to try out 1.1 with their code
+        before the full release.
+      </p>
+
+      <table class="downloads table table-hover table-responsive table-bordered">
+        <tbody>
+          <tr>
+            <th rowspan="2"> Windows Self-Extracting Archive (.exe) <a href="platform.html#windows">[帮助]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x86/1.1/julia-1.1.0-rc1-win32.exe">32-bit</a>
+            </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/winnt/x64/1.1/julia-1.1.0-rc1-win64.exe">64-bit</a>
+            </td>
+          </tr>
+          <tr>
+            <td colspan="6">Windows 7/Windows Server 2012 users also require
+              <a href="https://docs.microsoft.com/en-us/powershell/wmf/overview">Windows Management Framework 3.0 or
+                later</a></td>
+          </tr>
+          <tr>
+            <th> macOS 10.8+ Package (.dmg) <a href="platform.html#macos">[帮助]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/mac/x64/1.1/julia-1.1.0-rc1-mac64.dmg">64-bit</a>
+            </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for x86 <a href="platform.html#generic-binaries">[帮助]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x86/1.1/julia-1.1.0-rc1-linux-i686.tar.gz">32-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x86/1.1/julia-1.1.0-rc1-linux-i686.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-rc1-linux-x86_64.tar.gz">64-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-rc1-linux-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Generic Linux Binaries for ARM <a href="platform.html#generic-binaries">[帮助]</a></th>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.1/julia-1.1.0-rc1-linux-armv7l.tar.gz">32-bit
+                (ARMv7-a hard float)</a>
+              (<a href="https://julialang-s3.julialang.org/bin/linux/armv7l/1.1/julia-1.1.0-rc1-linux-armv7l.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="3"> </td>
+          </tr>
+          <tr>
+            <th> Generic FreeBSD Binaries for x86 <a href="platform.html#generic-binaries">[帮助]</a></th>
+            <td colspan="3"> </td>
+            <td colspan="3"> <a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.1/julia-1.1.0-rc1-freebsd-x86_64.tar.gz">64-bit</a>
+              (<a href="https://julialang-s3.julialang.org/bin/freebsd/x64/1.1/julia-1.1.0-rc1-freebsd-x86_64.tar.gz.asc">GPG</a>)
+            </td>
+          </tr>
+          <tr>
+            <th> Source </th>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.1.0-rc1/julia-1.1.0-rc1.tar.gz">Tarball</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.1.0-rc1/julia-1.1.0-rc1.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/releases/download/v1.1.0-rc1/julia-1.1.0-rc1-full.tar.gz">Tarball
+                with dependencies</a>
+              (<a href="https://github.com/JuliaLang/julia/releases/download/v1.1.0-rc1/julia-1.1.0-rc1-full.tar.gz.asc">GPG</a>)
+            </td>
+            <td colspan="2"> <a href="https://github.com/JuliaLang/julia/tree/v1.1.0-rc1">GitHub</a> </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div> -->
+  <!-- Upcoming release //END -->
+  
+  <br />
+  
+  <!-- 7.row = Older Releases -->
+  <!-- <div class="row">
+    <div class="col-12">
+      <h2>Older Releases</h2>
+      <p>
+        Older releases of Julia for all platforms are available on the <a href="oldreleases.html">Older releases page</a>.
+        Releases older than 0.6 are now unmaintained.
+      </p>
+    </div>
   </div>
-</div>
+  
+  <br /> -->
+  
+  <!-- 8.row = Nightly builds -->
+  <!-- <div class="row">
+    <div class="col-12">
+      <h2>Nightly builds</h2>
+      <p>
+        Nightly builds of the current unstable development version of Julia are available on the
+        <a href="nightlies.html">nightlies page</a>.
+        These are intended as developer previews into the latest work and are not intended for
+        normal use.
+        Most users are advised to use the current release version of Julia, above.
+      </p>
+    </div>
+  </div> 
+  
+  <br /> -->
+  
+  <!-- 9.row = Download verification -->
+  <!-- <div class="row">
+    <div class="col-12">
+      <h2>Download verification</h2>
+      <p>
+        All Julia binary releases are cryptographically secured using the traditional methods on each
+        operating system platform. macOS and Windows releases are codesigned by certificates that are
+        verified by the operating system before installation. Generic Linux tarballs and source tarballs
+        are signed via GPG using <a href="../juliareleases.asc">this key</a>. Ubuntu and Fedora/RHEL/CentOS/SL
+        releases are signed by their own keys that are verified by the package managers when installing.
+      </p>
+    </div>
+  </div> -->
 
+</div><!-- 1.container end -->
+
+<br />
+<!-- Julia 下载页结束 -->

--- a/downloads/platform.html
+++ b/downloads/platform.html
@@ -3,7 +3,6 @@ layout: homepage
 title:  Platform specific instructions for installing Julia
 ---
 
-{% include mainmenu.html %}
 
 <br /><br />
 
@@ -230,6 +229,3 @@ title:  Platform specific instructions for installing Julia
   </div>
 </div>
 
-{% include footermenu.html %}
-
-{% include footer.html %}

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@ julia_version: v1.0
 
 <br /><br />
 
+{% include ides.html %}
+
 {% include contact.html %}
 
 

--- a/meetups/index.md
+++ b/meetups/index.md
@@ -1,5 +1,5 @@
 ---
-layout: homepage
+layout: meetups
 title:  Julia用户见面会（Meetups）
 ---
 
@@ -7,9 +7,9 @@ Julia User Meet Up是Julia社区的传统活动。旨在为Julian互相分享技
 我们2015年在中国科学技术大学办了第一场国内的meetup，之后在深圳Haplox公司的赞助下办了第二场，随着Julia 1.0的临近
 我们今年将在**中国科学院软件研究所**办第三次用户小聚活动。
 
-活动内容的更新可以通过访问中文社区的主页获得：http://juliacn.com
+活动内容的更新可以通过访问中文社区的主页获得：[juliacn.com](https://juliacn.com)
 
-如果您无法在官网（julialang.org）上下载到编译器，可以通过我们境内的服务器下载：[Julia中文社区](http://47.95.118.149)
+如果您无法在官网（julialang.org）上下载到编译器，可以通过我们境内的服务器下载：[Julia中文社区](https://discourse.juliacn.com/)
 
 到目前为止，我们将有以下Julian分享自己的心得和技术：
 


### PR DESCRIPTION
- navbar 添加社区链接
- 修改 `homepage` 布局，适应宽屏
- 更新首页内容，微调语句及排版

详细变更见 commit msg

----

差不多可以把 juliacn.com 指向这个 repo 了。
并顺带把 [old.juliacn.github.io](https://github.com/JuliaCN/old.juliacn.github.io) 存档

- [Using a custom domain with GitHub Pages - User Documentation](https://help.github.com/articles/using-a-custom-domain-with-github-pages/)
- [Archiving a GitHub repository - User Documentation](https://help.github.com/articles/archiving-a-github-repository/)